### PR TITLE
limit max text length

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ set -g @forecast-format %C
 
 Refer to [wttr.in](http://wttr.in) for format options.
 
+Moreover a character limit is enforced, in order to avoid errors trashing your status bar.
+This limit defaults to 75, but you can increase/decrease it as you wish:
+
+```bash
+set -g @forecast-char-limit 30
+```
+
 ## Installation with [Tmux Plugin Manager](https://github.com/tmux-plugins/tpm) (recommended)
 
 Add plugin to the list of TPM plugins in `.tmux.conf`:

--- a/scripts/forecast.sh
+++ b/scripts/forecast.sh
@@ -6,7 +6,9 @@ source "$CURRENT_DIR/helpers.sh"
 
 print_forecast() {
   local format=$(get_tmux_option @forecast-format "%C+%t+%w")
-  echo $(curl http://wttr.in/?format=$format)
+  local char_limit=$(get_tmux_option @forecast-char-limit 75)
+  local forecast=$(curl http://wttr.in/?format=$format)
+  echo ${forecast:0:$char_limit}
 }
 
 main() {


### PR DESCRIPTION
Hello,
In this exact moment, wttr.in is broken and the error message is quite longer than the weather. This makes my status bar sadly disappear :/

I propose this workaround to limit the characters displayed.

Feel free to rewrite/improve both the bash and the English side, as I'm not a native speaker of either :D

