### PR TITLE
Add location option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ set -g @forecast-format %C
 
 Refer to [wttr.in](http://wttr.in) for format options.
 
+Additionally, you might want to specify the location manually, you can do so with the `@forecast-location` option:
+
+```bash
+set -g @forecast-format London
+```
+
+Refer to [wttr.in](https://wttr.in/:help) for location options.
+
 Moreover a character limit is enforced, in order to avoid errors trashing your status bar.
 This limit defaults to 75, but you can increase/decrease it as you wish:
 

--- a/scripts/forecast.sh
+++ b/scripts/forecast.sh
@@ -6,8 +6,9 @@ source "$CURRENT_DIR/helpers.sh"
 
 print_forecast() {
   local format=$(get_tmux_option @forecast-format "%C+%t+%w")
+  local location=$(get_tmux_option @forecast-location "") # Let wttr.in figure out the location
   local char_limit=$(get_tmux_option @forecast-char-limit 75)
-  local forecast=$(curl http://wttr.in/?format=$format)
+  local forecast=$(curl http://wttr.in/$location?format=$format)
   echo ${forecast:0:$char_limit}
 }
 


### PR DESCRIPTION
The option to specify location can be set with:
`set -g @forecast-location [VALUE]`

The contents of that field are passed as-is to `wttr.in`.
By default, option is empty letting `wttr.in` figure out the location.

Addresses #5 
