### PR TITLE
Add optional file cache for forecast result

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This limit defaults to 75, but you can increase/decrease it as you wish:
 set -g @forecast-char-limit 30
 ```
 
-It's posible to enable cache for weather data in file and use it instead of spamming wttr.in
+It's possible to enable cache for weather data in file and use it instead of spamming wttr.in
 service. Weather (and forecast) doesn't change every minute (or even every second) so no need to add
 extra load on wttr.in in case your status-line updated quite often.
 To enable caching just set its duration in seconds

--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ This limit defaults to 75, but you can increase/decrease it as you wish:
 set -g @forecast-char-limit 30
 ```
 
+It's posible to enable cache for weather data in file and use it instead of spamming wttr.in
+service. Weather (and forecast) doesn't change every minute (or even every second) so no need to add
+extra load on wttr.in in case your status-line updated quite often.
+To enable caching just set its duration in seconds
+
+```bash
+set -g @forecast-cache-duration 900 # 15 minutes
+```
+
+There is also an option where to store the cache file
+
+```bash
+# this is the default
+set -g @forecast-cache-path "/tmp/tmux-weather.cache"
+```
+
 ## Installation with [Tmux Plugin Manager](https://github.com/tmux-plugins/tpm) (recommended)
 
 Add plugin to the list of TPM plugins in `.tmux.conf`:

--- a/scripts/forecast.sh
+++ b/scripts/forecast.sh
@@ -4,11 +4,37 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source "$CURRENT_DIR/helpers.sh"
 
-print_forecast() {
+get_forecast() {
   local format=$(get_tmux_option @forecast-format "%C+%t+%w")
   local location=$(get_tmux_option @forecast-location "") # Let wttr.in figure out the location
+  curl "http://wttr.in/$location?format=$format"
+}
+
+get_cached_forecast() {
+  local cache_duration=$(get_tmux_option @forecast-cache-duration 0) # in seconds, by default cache is disabled
+  local cache_path=$(get_tmux_option @forecast-cache-path "/tmp/tmux-weather.cache") # where to store the cached data
+  local cache_age=$(get_file_age "$cache_path")
+  local forecast
+  if [ $cache_duration -gt 0 ]; then # Cache enabled branch
+    # if file does not exist or cache age is greater then configured duration
+    if ! [ -f "$cache_path" ] || [ $cache_age -ge $cache_duration ]; then
+      forecast=$(get_forecast)
+      # store forecast in $cache_path
+      mkdir -p "$(dirname "$cache_path")"
+      echo "$forecast" > "$cache_path"
+    else
+      # otherwise try to get it from cache file
+      forecast=$(cat "$cache_path" 2>/dev/null)
+    fi
+  else # Cache disabled branch
+    forecast=$(get_forecast)
+  fi
+  echo "$forecast"
+}
+
+print_forecast() {
   local char_limit=$(get_tmux_option @forecast-char-limit 75)
-  local forecast=$(curl http://wttr.in/$location?format=$format)
+  local forecast=$(get_cached_forecast)
   echo ${forecast:0:$char_limit}
 }
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -16,3 +16,16 @@ get_tmux_option() {
     echo "$option_value"
   fi
 }
+
+# get files age in seconds
+get_file_age() { # $1 - cache file
+  local file_path="${1:-}"
+  local now=$(date +%s)
+  local file_modification_timestamp=$(stat -c "%Y" "$file_path" 2>/dev/null || echo 0)
+  if [ $file_modification_timestamp -ne 0 ]; then
+    echo $((now - file_modification_timestamp))
+  else
+    # return 0 if could not get cache modification time, eg. file does not exist
+    echo 0
+  fi
+}


### PR DESCRIPTION
The PR adds an optional cache (in file) for weather data and use it instead of spamming wttr.in service. 
Weather (and forecast) doesn't change every minute (or even every second) so no need to add
extra load on wttr.in in case status-line is configured to update quite often.